### PR TITLE
Forgotten verb in section 5 added

### DIFF
--- a/index.html
+++ b/index.html
@@ -645,7 +645,7 @@ dl.dl-horizontal > dd {
 <section >
     <!-- Editor - @halindrome -->
     <h2>User sequences</h2>
-    <p>The transaction examples in this section basic ways in which Verifiable Claims 
+    <p>The transaction examples in this section show basic ways in which Verifiable Claims 
     might be used.  They are not meant to be architecturally constraining. Instead,
     they are meant to help illustrate the basic way it <em>could</em> be done in a
     typical commerce situation.


### PR DESCRIPTION
Fixes #12
Sentence in Sec 5 has verb left out; nonsensical:
“The transaction examples in this section basic ways in which Verifiable Claims might be used.”

changed by adding verb ‘show’:
“The transaction examples in this section show basic ways in which Verifiable Claims might be used.”